### PR TITLE
Agrega un hack para la grid de participantes

### DIFF
--- a/src/PlayerBox.tsx
+++ b/src/PlayerBox.tsx
@@ -10,6 +10,7 @@ interface PlayerViewProps {
   onTap?: () => void
   selected: number
   selectedCount?: number
+  onLayout: React.ComponentProps<typeof View>['onLayout']
 }
 
 const colors = ['', '#FFFFFF', '#7D7D7D', '#F7E05A', '#CD6B1D']
@@ -19,10 +20,12 @@ const PlayerBox: React.FC<PlayerViewProps> = ({
   player,
   onTap,
   selected,
-  selectedCount
+  selectedCount,
+  onLayout
 }) => {
   return (
     <TouchableHighlight
+      onLayout={onLayout}
       onPress={onTap}
       underlayColor={
         underlayColors[selected > 0 ? selected - 1 : selectedCount || 0]

--- a/src/SelectPlayers.tsx
+++ b/src/SelectPlayers.tsx
@@ -3,10 +3,12 @@ import React, { useState } from 'react'
 import { Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { NavigationStackScreenProps } from 'react-navigation-stack'
+
 import { PlayerData } from '@src/ranking'
 import PlayerBox from '@src/PlayerBox'
 import RoundedButton from '@src/RoundedButton'
-import { NavigationStackScreenProps } from 'react-navigation-stack'
+import PatoGrid from '@src/components/PatoGrid'
 
 interface SelectPlayersProps {
   players: PlayerData[]
@@ -26,14 +28,7 @@ const SelectPlayers: React.FC<SelectPlayersProps> = ({
         margin: 0
       }}
     >
-      <View
-        style={{
-          width: '100%',
-          flexDirection: 'row',
-          flexWrap: 'wrap',
-          justifyContent: 'space-evenly'
-        }}
-      >
+      <PatoGrid>
         {players.map(item => (
           <PlayerBox
             key={item.id}
@@ -43,7 +38,7 @@ const SelectPlayers: React.FC<SelectPlayersProps> = ({
             selectedCount={selectedIds.length}
           />
         ))}
-      </View>
+      </PatoGrid>
     </ScrollView>
   )
 }

--- a/src/components/PatoGrid.tsx
+++ b/src/components/PatoGrid.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import { times } from 'ramda'
+import { View } from 'react-native'
+
+/**
+ * Hack to get a flex layout to behave sort of like a grid.
+ *
+ * It fills a flex container with a bunch of placeholder elements of the same
+ * width as the first child given. This, combined with `space-evenly`, aligns
+ * the elements in columns. It only tries to set the placeholder width once,
+ * so it's important that elements are all of the same width and that the width
+ * doesn't change.
+ */
+function PatoGrid({ children }: Props) {
+  const [placeholderWidth, setPlaceholderWidth] = useState<number | null>(null)
+
+  return (
+    <View
+      style={{
+        width: '100%',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'space-evenly'
+      }}
+    >
+      {React.Children.map(children, (child, i) => {
+        if (placeholderWidth !== null || i > 0) {
+          return child
+        }
+
+        return React.cloneElement<OnLayoutElementProps>(child, {
+          onLayout: ({ nativeEvent }) =>
+            setPlaceholderWidth(nativeEvent.layout.width)
+        })
+      })}
+
+      {placeholderWidth !== null &&
+        times(i => <View key={i} style={{ width: placeholderWidth }} />, 20)}
+    </View>
+  )
+}
+
+type OnLayoutElementProps = {
+  onLayout: React.ComponentProps<typeof View>['onLayout']
+}
+
+type ElementWithOnLayout = React.ReactElement<OnLayoutElementProps>
+
+interface Props {
+  children: ElementWithOnLayout | Array<ElementWithOnLayout>
+}
+
+export default PatoGrid


### PR DESCRIPTION
Una cosa que no logré tipar bien es que los children de `PatoGrid` sí o sí tengan que tener `onLayout`, de momento le podés pasar cualquier cosa que sea un `children` válido y a TS no le va a importar.

Fixes #23.

![image](https://user-images.githubusercontent.com/1302493/73139714-a26f0400-404f-11ea-98ea-09a4de7768aa.png)
